### PR TITLE
Replace undent heredoc with Ruby native heredoc

### DIFF
--- a/Formula/fourstore-ncbo.rb
+++ b/Formula/fourstore-ncbo.rb
@@ -29,20 +29,21 @@ class FourstoreNcbo < Formula
     system "make", "install"
   end
 
-  def caveats; <<~EOS
-    Databases will be created at #{var}/fourstore.
+  def caveats
+    <<~EOS
+      Databases will be created at #{var}/fourstore.
 
-    Create and start up a database:
-        4s-backend-setup mydb
-        4s-backend mydb
+      Create and start up a database:
+          4s-backend-setup mydb
+          4s-backend mydb
 
-    Load RDF data:
-        4s-import mydb datafile.rdf
+      Load RDF data:
+          4s-import mydb datafile.rdf
 
-    Start up HTTP SPARQL server without daemonizing:
-        4s-httpd -p 8000 -D mydb
+      Start up HTTP SPARQL server without daemonizing:
+          4s-httpd -p 8000 -D mydb
 
-    See http://github.com/garlik/4store for more information.
+      See http://github.com/garlik/4store for more information.
     EOS
   end
 

--- a/Formula/fourstore-ncbo.rb
+++ b/Formula/fourstore-ncbo.rb
@@ -8,19 +8,16 @@ class FourstoreNcbo < Formula
   sha256 "1da20d132065ce6d12df5de2b3423d719680259822ada0029132b571df031745"
   revision 1
 
-  depends_on 'pkg-config' => :build
-  depends_on 'libtool' => :build
-  depends_on 'glib'
-  depends_on 'raptor'
-  depends_on 'rasqal'
-  depends_on 'pcre'
-
-  if build.head?
-    depends_on "gettext"
-    depends_on "autogen"
-    depends_on "autoconf"
-    depends_on "automake"
-  end
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "autogen"
+  depends_on "gettext"
+  depends_on "glib"
+  depends_on "pcre"
+  depends_on "raptor"
+  depends_on "rasqal"
 
   def install
     args  = ["--prefix=#{prefix}",

--- a/Formula/fourstore-ncbo.rb
+++ b/Formula/fourstore-ncbo.rb
@@ -38,7 +38,7 @@ class FourstoreNcbo < Formula
     system "make install"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Databases will be created at #{var}/fourstore.
 
     Create and start up a database:

--- a/Formula/fourstore-ncbo.rb
+++ b/Formula/fourstore-ncbo.rb
@@ -5,7 +5,7 @@ class FourstoreNcbo < Formula
   homepage "https://github.com/ncbo/4store"
   url "https://github.com/ncbo/4store/archive/v1.1.6-NCBO-SNAPSHOT-1.tar.gz"
   head "git@github.com:ncbo/4store.git"
-  sha256 "5420a048b5e7c5abc5a95f24ab17ab4c9b90bc012dbf97e16aeab07f095aa102"
+  sha256 "1da20d132065ce6d12df5de2b3423d719680259822ada0029132b571df031745"
   revision 1
 
   depends_on 'pkg-config' => :build

--- a/Formula/fourstore-ncbo.rb
+++ b/Formula/fourstore-ncbo.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class FourstoreNcbo < Formula
   desc "Fourstore RDF database, customized for BioPortal"
-  homepage 'http://4store.org/'
+  homepage "https://github.com/ncbo/4store"
 
   if build.include? 'ncbo'
     head 'git://github.com/ncbo/4store.git'

--- a/Formula/fourstore-ncbo.rb
+++ b/Formula/fourstore-ncbo.rb
@@ -3,14 +3,10 @@ require 'formula'
 class FourstoreNcbo < Formula
   desc "Fourstore RDF database, customized for BioPortal"
   homepage "https://github.com/ncbo/4store"
-
-  if build.include? 'ncbo'
-    head 'git://github.com/ncbo/4store.git'
-  else
-    url 'http://github.com/garlik/4store/archive/v1.1.5.tar.gz'
-    head 'git@github.com:garlik/4store.git'
-    sha256 '5420a048b5e7c5abc5a95f24ab17ab4c9b90bc012dbf97e16aeab07f095aa102'
-  end
+  url "https://github.com/ncbo/4store/archive/v1.1.6-NCBO-SNAPSHOT-1.tar.gz"
+  head "git@github.com:ncbo/4store.git"
+  sha256 "5420a048b5e7c5abc5a95f24ab17ab4c9b90bc012dbf97e16aeab07f095aa102"
+  revision 1
 
   depends_on 'pkg-config' => :build
   depends_on 'libtool' => :build

--- a/Formula/fourstore-ncbo.rb
+++ b/Formula/fourstore-ncbo.rb
@@ -20,16 +20,13 @@ class FourstoreNcbo < Formula
   depends_on "rasqal"
 
   def install
-    args  = ["--prefix=#{prefix}",
-            "--with-storage-path=#{var}/fourstore",
-            ]
-    if build.head? then
-      require "Date"
-      system "echo '#{DateTime.now.to_s}--trunk' > ./.version"
-      system "./autogen.sh --verbose"
-    end
-    system "./configure", *args
-    system "make install"
+    (buildpath/".version").write("v1.1.6-NCBO-SNAPSHOT-1")
+    system "./autogen.sh"
+    (var/"fourstore").mkpath
+    system "./configure", "--prefix=#{prefix}", 
+                          "--with-storage-path=#{var}/fourstore", 
+                          "--sysconfdir=#{etc}/fourstore"
+    system "make", "install"
   end
 
   def caveats; <<~EOS

--- a/Formula/fourstore-ncbo.rb
+++ b/Formula/fourstore-ncbo.rb
@@ -43,7 +43,7 @@ class FourstoreNcbo < Formula
       Start up HTTP SPARQL server without daemonizing:
           4s-httpd -p 8000 -D mydb
 
-      See http://github.com/garlik/4store for more information.
+      See https://github.com/ncbo/4store for more information.
     EOS
   end
 

--- a/Formula/fourstore-ncbo.rb
+++ b/Formula/fourstore-ncbo.rb
@@ -1,6 +1,7 @@
 require 'formula'
 
 class FourstoreNcbo < Formula
+  desc "Fourstore RDF database, customized for BioPortal"
   homepage 'http://4store.org/'
 
   if build.include? 'ncbo'


### PR DESCRIPTION
Commands like `brew info fourstore-ncbo` throw:

```
Error: undefined method `undent' for #<String:0x00007f965330aed0>
Please report this issue:
  https://docs.brew.sh/Troubleshooting
/usr/local/Homebrew/Library/Taps/msalvadores/homebrew-fourstore/Formula/fourstore-ncbo.rb:41:in `caveats'
/usr/local/Homebrew/Library/Homebrew/caveats.rb:19:in `caveats'
...
```

The undent method has been removed: https://github.com/Homebrew/homebrew-cask/issues/49716#issuecomment-406669679.